### PR TITLE
Fix double-mean bug in climatology when detrend='none'

### DIFF
--- a/cdt/climatology.m
+++ b/cdt/climatology.m
@@ -234,8 +234,9 @@ end
 
 %% Build climatology: 
 % It's just the seasonal component plus the mean: 
+   
+if ~strncmpi(DetrendOption,'mean',3) && ~strncmpi(DetrendOption,'none',3)
 
-if ~strncmpi(DetrendOption,'mean',3)
    Ac = Ac + meanAr; 
 end
 


### PR DESCRIPTION
When running climatology with ('detrend','none'), the mean of the data is added to the output twice. The 'none' option skips the initial detrending step, so the mean remains inside Ac. Then meanAr is added back unconditionally at the end, doubling it.

Fix: extend the conditional to also exclude the 'none' case.

On the buggy code this reproducer will return all 20s for a string of constant 10s before the fix:

    t = datenum(2000,1,1):datenum(2000,12,31);
    data = ones(size(t)) * 10;
    clim = climatology(data, t, 'daily', 'detrend', 'none');
    mean(clim)  % returns 20 instead of 10 before fix